### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var async = require('async');
 var events = require('events');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var util = require('util');
 
 

--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
-	"name": "bodacious",
-	"version": "0.6.0",
-	"author": "makesites",
-	"description": "Job manager with multiple store support, based on Bull",
-	"keywords": [
-		"job",
-		"queue",
-		"task",
-		"parallel"
-	],
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/makesites/bodacious.git"
-	},
-	"main": "index.js",
-	"scripts": {
-		"test": "mocha test/* --reporter spec",
-		"postpublish": "git push && git push --tags"
-	},
-	"dependencies": {
-		"async": "1.5.2",
-		"node-uuid": "~1.4.1",
-		"redis": "0.8.6",
-		"underscore": "1.8.0"
-	},
-	"devDependencies": {
-		"expect.js": "~0.2.0",
-		"lodash": "~4.3.0",
-		"sinon": "~1.12.1",
-		"mocha": "~1.21.4"
-	}
+  "name": "bodacious",
+  "version": "0.6.0",
+  "author": "makesites",
+  "description": "Job manager with multiple store support, based on Bull",
+  "keywords": [
+    "job",
+    "queue",
+    "task",
+    "parallel"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/makesites/bodacious.git"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha test/* --reporter spec",
+    "postpublish": "git push && git push --tags"
+  },
+  "dependencies": {
+    "async": "1.5.2",
+    "redis": "0.8.6",
+    "underscore": "1.8.0",
+    "uuid": "^3.0.0"
+  },
+  "devDependencies": {
+    "expect.js": "~0.2.0",
+    "lodash": "~4.3.0",
+    "sinon": "~1.12.1",
+    "mocha": "~1.21.4"
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.